### PR TITLE
Use full alphanumeric characters for the Wi-Fi password

### DIFF
--- a/OTPAuth-M5StickC/OTPAuth-M5StickC.ino
+++ b/OTPAuth-M5StickC/OTPAuth-M5StickC.ino
@@ -14,7 +14,9 @@
 //#define timeout_ScreenOn 180000 // Shutdown time
 
 
-String random_letters = "AEF2345689";      // This string contains the characters used to generate the wifi password
+char random_letters[] = "0123456789"
+                        "abcdefghijklmnopqrstuvwxyz"
+                        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"; // This string contains the characters used to generate the wifi password
 
 #include <WiFi.h>
 #include <WebServer.h>

--- a/OTPAuth-M5StickC/screen2.h
+++ b/OTPAuth-M5StickC/screen2.h
@@ -17,7 +17,7 @@ void Wifi_screen() {
   /* generate password for wifi */
   String pass_gen = "";
   for (int i = 0; i < 8; i++) {
-    pass_gen += random_letters[random(0, random_letters.length() - 1)];
+    pass_gen += random_letters[random(0, sizeof(random_letters) - 1)];
   }
 
   String pass_static = "";  // Default password


### PR DESCRIPTION
Since we are no longer using a highly stylized font, there is no need to reduce the characters used for password generation